### PR TITLE
version bindings for available Nix versions

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,9 @@
 {pkgs ? import <nixpkgs> {}}: let
-  nixForBindings = pkgs.nixVersions.nix_2_28;
+  nixForBindings = [
+    pkgs.nixVersions.nix_2_28
+    pkgs.nixVersions.nix_2_29
+    pkgs.nixVersions.latest
+  ];
 in
   pkgs.mkShell {
     name = "nix-bindings";
@@ -14,12 +18,12 @@ in
       lldb
     ];
 
-    nativeBuildInputs = with pkgs; [
-      nixForBindings.dev
-      pkg-config
-      glibc.dev
-      #gcc
-    ];
+    nativeBuildInputs =
+      (with pkgs; [
+        pkg-config
+        glibc.dev
+      ])
+      ++ map (nix: nix.dev) nixForBindings;
 
     env = {
       RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-pub mod bindings {
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-}
-pub use bindings::*;
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+// Versioned exports
+include!(concat!(env!("OUT_DIR"), "/versions_mod.rs"));


### PR DESCRIPTION
Should allow exporting multiple versions of bindings at once. We'd like to make this into crate features eventually.