### PR TITLE
various: feature-gate C API components

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {

--- a/nix-bindings-sys/Cargo.toml
+++ b/nix-bindings-sys/Cargo.toml
@@ -12,6 +12,15 @@ publish                = true
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]
 
+[features]
+default = [ "full" ]
+expr    = [  ]
+flake   = [  ]
+full    = [ "store", "expr", "util", "flake", "main" ]
+main    = [  ]
+store   = [  ]
+util    = [  ]
+
 [lib]
 path = "lib.rs"
 

--- a/nix-bindings-sys/build.rs
+++ b/nix-bindings-sys/build.rs
@@ -24,17 +24,6 @@ fn main() {
   // Tell cargo to invalidate the built crate whenever the wrapper changes
   println!("cargo:rerun-if-changed=include/wrapper.h");
 
-  // Use pkg-config to find nix-store include and link paths
-  // This NEEDS to be included, or otherwise `nix_api_store.h` cannot
-  // be found.
-  let nix_libraries = [
-    "nix-main-c",
-    "nix-expr-c",
-    "nix-store-c",
-    "nix-util-c",
-    "nix-flake-c",
-  ];
-
   // Dynamically get GCC's include path for standard headers (e.g., stdbool.h)
   let gcc_include = Command::new("gcc")
     .arg("-print-file-name=include")
@@ -49,20 +38,37 @@ fn main() {
     .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
     .formatter(bindgen::Formatter::Rustfmt)
     .rustfmt_configuration_file(std::fs::canonicalize(".rustfmt.toml").ok())
-    .parse_callbacks(Box::new(ProcessComments));
+    .parse_callbacks(Box::new(ProcessComments))
+    .clang_arg(format!("-I{gcc_include}"));
 
-  // Add all pkg-config include paths and GCC's include path to bindgen
-  for nix_lib in nix_libraries {
-    let lib = pkg_config::probe_library(nix_lib)
-      .unwrap_or_else(|_| panic!("Unable to find .pc file for {nix_lib}"));
-    for include_path in lib.include_paths {
-      builder = builder.clang_arg(format!("-I{}", include_path.display()));
-    }
-    for link_file in lib.link_files {
-      println!("cargo:rustc-link-lib={}", link_file.display());
+  // For each enabled feature, probe the matching C library and add the
+  // corresponding preprocessor define so wrapper.h includes the right headers.
+  //
+  // (Cargo feature env var, preprocessor define, pkg-config lib name)
+  let libraries: &[(&str, &str, &str)] = &[
+    ("CARGO_FEATURE_STORE", "FEATURE_STORE", "nix-store-c"),
+    ("CARGO_FEATURE_EXPR", "FEATURE_EXPR", "nix-expr-c"),
+    ("CARGO_FEATURE_UTIL", "FEATURE_UTIL", "nix-util-c"),
+    ("CARGO_FEATURE_FLAKE", "FEATURE_FLAKE", "nix-flake-c"),
+    ("CARGO_FEATURE_MAIN", "FEATURE_MAIN", "nix-main-c"),
+  ];
+
+  for (feat_var, define, lib_name) in libraries {
+    if env::var(feat_var).is_ok() {
+      let lib = pkg_config::probe_library(lib_name)
+        .unwrap_or_else(|_| panic!("Unable to find .pc file for {lib_name}"));
+
+      for include_path in lib.include_paths {
+        builder = builder.clang_arg(format!("-I{}", include_path.display()));
+      }
+
+      for link_file in lib.link_files {
+        println!("cargo:rustc-link-lib={}", link_file.display());
+      }
+
+      builder = builder.clang_arg(format!("-D{define}"));
     }
   }
-  builder = builder.clang_arg(format!("-I{gcc_include}"));
 
   // Write the bindings to the $OUT_DIR/bindings.rs file
   let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/nix-bindings-sys/include/wrapper.h
+++ b/nix-bindings-sys/include/wrapper.h
@@ -1,20 +1,25 @@
-// Pure C API for store operations
+// This file is a meta-wrapper for bindgen. Each section is guarded by
+// a preprocessor define so that only the headers mapped to enabled Cargo
+// features are actually included.
+
+#ifdef FEATURE_STORE
 #include <nix_api_store.h>
+#endif
 
-// Pure C API for error handling
+#ifdef FEATURE_UTIL
 #include <nix_api_util.h>
-
-// Pure C API for the Nix evaluator
-#include <nix_api_expr.h>
-
-// Pure C API for external values
 #include <nix_api_external.h>
+#endif
 
-// Pure C API for value manipulation
+#ifdef FEATURE_EXPR
+#include <nix_api_expr.h>
 #include <nix_api_value.h>
+#endif
 
-// Pure C API for flake support
+#ifdef FEATURE_FLAKE
 #include <nix_api_flake.h>
+#endif
 
-// Pure C API for main/CLI support
+#ifdef FEATURE_MAIN
 #include <nix_api_main.h>
+#endif

--- a/nix-bindings/Cargo.toml
+++ b/nix-bindings/Cargo.toml
@@ -9,8 +9,17 @@ rust-version.workspace = true
 license.workspace      = true
 publish                = true
 
-[lib]
-path = "src/lib.rs"
+[features]
+default = [ "full" ]
+full    = [ "nix-bindings-sys/full", "store", "expr", "util", "flake", "main", "external", "primop" ]
+
+expr     = [ "store", "nix-bindings-sys/expr" ]
+external = [ "store", "nix-bindings-sys/util" ]
+flake    = [ "expr", "nix-bindings-sys/flake" ]
+main     = [ "nix-bindings-sys/main" ]
+primop   = [ "expr", "nix-bindings-sys/expr" ]
+store    = [ "nix-bindings-sys/store", "nix-bindings-sys/expr", "nix-bindings-sys/util" ]
+util     = [ "nix-bindings-sys/util" ]
 
 [dependencies]
 nix-bindings-sys.workspace = true

--- a/nix-bindings/src/lib.rs
+++ b/nix-bindings/src/lib.rs
@@ -7,19 +7,23 @@
 //! # Quick Start
 //!
 //! ```no_run
-//! use std::sync::Arc;
+//! #[cfg(feature = "store")]
+//! {
+//!   use std::sync::Arc;
 //!
-//! use nix_bindings::{Context, EvalStateBuilder, Store};
+//!   use nix_bindings::{Context, EvalStateBuilder, Store};
 //!
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let ctx = Arc::new(Context::new()?);
-//! let store = Arc::new(Store::open(&ctx, None)?);
-//! let state = EvalStateBuilder::new(&store)?.build()?;
+//!   fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let ctx = Arc::new(Context::new()?);
+//!     let store = Arc::new(Store::open(&ctx, None)?);
+//!     let state = EvalStateBuilder::new(&store)?.build()?;
 //!
-//! let result = state.eval_from_string("1 + 2", "<eval>")?;
-//! println!("Result: {}", result.as_int()?);
-//! # Ok(())
-//! # }
+//!     let result = state.eval_from_string("1 + 2", "<eval>")?;
+//!     println!("Result: {}", result.as_int()?);
+//!
+//!     Ok(())
+//!   }
+//! }
 //! ```
 //!
 //! # Value Formatting
@@ -27,44 +31,60 @@
 //! Values support multiple formatting options:
 //!
 //! ```no_run
-//! # use std::sync::Arc;
-//! # use nix_bindings::{Context, EvalStateBuilder, Store};
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let ctx = Arc::new(Context::new()?);
-//! # let store = Arc::new(Store::open(&ctx, None)?);
-//! # let state = EvalStateBuilder::new(&store)?.build()?;
-//! let value = state.eval_from_string("\"hello world\"", "<eval>")?;
+//! #[cfg(feature = "expr")]
+//! {
+//!   use std::sync::Arc;
 //!
-//! // Display formatting (user-friendly)
-//! println!("{}", value); // Output: hello world
+//!   use nix_bindings::{Context, EvalStateBuilder, Store};
+//!   fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let ctx = Arc::new(Context::new()?);
+//!     let store = Arc::new(Store::open(&ctx, None)?);
+//!     let state = EvalStateBuilder::new(&store)?.build()?;
+//!     let value = state.eval_from_string("\"hello world\"", "<eval>")?;
 //!
-//! // Debug formatting (with type info)
-//! println!("{:?}", value); // Output: Value::String("hello world")
+//!     // Display formatting (user-friendly)
+//!     println!("{}", value); // => hello world
 //!
-//! // Nix syntax formatting
-//! println!("{}", value.to_nix_string()?); // Output: "hello world"
-//! //
-//! # Ok(())
-//! # }
+//!     // Debug formatting (with type info)
+//!     println!("{:?}", value); // => Value::String("hello world")
+//!
+//!     // Nix syntax formatting
+//!     println!("{}", value.to_nix_string()?); // => "hello world"
+//!     //
+//!     Ok(())
+//!   }
+//! }
 //! ```
 
-mod attrs;
-pub mod external;
-pub mod flake;
-mod lists;
-pub mod primop;
-mod store;
-
+use std::fmt;
+#[cfg(any(
+  feature = "store",
+  feature = "expr",
+  feature = "flake",
+  feature = "external",
+  feature = "primop"
+))]
 use std::{
   ffi::{CStr, CString},
-  fmt,
-  path::Path,
   ptr::NonNull,
-  sync::Arc,
 };
+#[cfg(any(
+  feature = "expr",
+  feature = "flake",
+  feature = "external",
+  feature = "primop"
+))]
+use std::{path::Path, sync::Arc};
 
-#[cfg(test)] use serial_test::serial;
-pub use store::{Derivation, Store, StorePath};
+#[cfg(feature = "expr")] mod attrs;
+#[cfg(feature = "expr")] mod lists;
+
+#[cfg(feature = "external")] pub mod external;
+#[cfg(feature = "flake")] pub mod flake;
+#[cfg(feature = "primop")] pub mod primop;
+
+#[cfg(all(test, any(feature = "store", feature = "expr")))]
+use serial_test::serial;
 
 /// Raw, unsafe FFI bindings to the Nix C API.
 ///
@@ -144,6 +164,10 @@ impl From<std::ffi::NulError> for Error {
   }
 }
 
+#[cfg(feature = "store")] mod store;
+#[cfg(feature = "store")]
+pub use store::{Derivation, Store, StorePath};
+
 /// Extract a string from a Nix context using a callback-based API.
 ///
 /// Many Nix C API functions return strings via callbacks. This helper
@@ -152,6 +176,7 @@ impl From<std::ffi::NulError> for Error {
 /// # Safety
 ///
 /// `call` must invoke `callback` with a valid string pointer and length.
+#[cfg(feature = "store")]
 unsafe fn string_from_callback<F>(call: F) -> Option<String>
 where
   F: FnOnce(sys::nix_get_string_callback, *mut std::os::raw::c_void),
@@ -177,6 +202,7 @@ where
 
 /// Check a Nix error code and convert to `Result`, extracting the real
 /// error message from the context.
+#[cfg(feature = "store")]
 fn check_err(ctx: *mut sys::nix_c_context, err: sys::nix_err) -> Result<()> {
   if err == sys::nix_err_NIX_OK {
     return Ok(());
@@ -221,6 +247,7 @@ fn check_err(ctx: *mut sys::nix_c_context, err: sys::nix_err) -> Result<()> {
 /// Return the version of the Nix library being used.
 ///
 /// This is a free function that does not require a context.
+#[cfg(feature = "store")]
 #[must_use]
 pub fn nix_version() -> &'static str {
   // SAFETY: nix_version_get returns a pointer to a static string literal
@@ -235,6 +262,7 @@ pub fn nix_version() -> &'static str {
 }
 
 /// Verbosity level for Nix log output.
+#[cfg(feature = "store")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verbosity {
   /// Only errors.
@@ -255,6 +283,7 @@ pub enum Verbosity {
   Vomit,
 }
 
+#[cfg(feature = "store")]
 impl Verbosity {
   fn to_c(self) -> sys::nix_verbosity {
     match self {
@@ -274,10 +303,12 @@ impl Verbosity {
 ///
 /// This is the root object for all Nix operations. It manages the lifetime
 /// of the Nix C API context and provides automatic cleanup.
+#[cfg(feature = "store")]
 pub struct Context {
   inner: NonNull<sys::nix_c_context>,
 }
 
+#[cfg(feature = "store")]
 impl Context {
   /// Create a new Nix context.
   ///
@@ -380,6 +411,7 @@ impl Context {
   }
 }
 
+#[cfg(feature = "store")]
 impl Drop for Context {
   fn drop(&mut self) {
     // SAFETY: We own the context and it's valid until drop
@@ -389,14 +421,17 @@ impl Drop for Context {
   }
 }
 
-// SAFETY: Context can be shared between threads
+#[cfg(feature = "store")]
 unsafe impl Send for Context {}
+
+#[cfg(feature = "store")]
 unsafe impl Sync for Context {}
 
 /// Builder for Nix evaluation state.
 ///
 /// This allows configuring the evaluation environment before creating
 /// the evaluation state.
+#[cfg(feature = "expr")]
 pub struct EvalStateBuilder {
   inner:     NonNull<sys::nix_eval_state_builder>,
   store:     Arc<Store>,
@@ -404,6 +439,7 @@ pub struct EvalStateBuilder {
   skip_load: bool,
 }
 
+#[cfg(feature = "expr")]
 impl EvalStateBuilder {
   /// Create a new evaluation state builder.
   ///
@@ -472,6 +508,7 @@ impl EvalStateBuilder {
   /// # Errors
   ///
   /// Returns an error if the flake settings cannot be applied.
+  #[cfg(feature = "flake")]
   pub fn with_flake_settings(
     self,
     settings: &flake::FlakeSettings,
@@ -539,6 +576,7 @@ impl EvalStateBuilder {
   }
 }
 
+#[cfg(feature = "expr")]
 impl Drop for EvalStateBuilder {
   fn drop(&mut self) {
     // SAFETY: We own the builder and it's valid until drop
@@ -552,6 +590,7 @@ impl Drop for EvalStateBuilder {
 ///
 /// This provides the main interface for evaluating Nix expressions
 /// and creating values.
+#[cfg(feature = "expr")]
 pub struct EvalState {
   pub(crate) inner:   NonNull<sys::EvalState>,
   #[expect(dead_code, reason = "keeps the Arc<Store> alive Drop side-effects")]
@@ -559,6 +598,7 @@ pub struct EvalState {
   pub(crate) context: Arc<Context>,
 }
 
+#[cfg(feature = "expr")]
 impl EvalState {
   /// Evaluate a Nix expression from a string.
   ///
@@ -892,6 +932,7 @@ impl EvalState {
   }
 }
 
+#[cfg(feature = "expr")]
 impl Drop for EvalState {
   fn drop(&mut self) {
     // SAFETY: We own the state and it's valid until drop
@@ -901,11 +942,14 @@ impl Drop for EvalState {
   }
 }
 
-// SAFETY: EvalState can be shared between threads
+#[cfg(feature = "expr")]
 unsafe impl Send for EvalState {}
+
+#[cfg(feature = "expr")]
 unsafe impl Sync for EvalState {}
 
 /// Nix value types.
+#[cfg(feature = "expr")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueType {
   /// Thunk (unevaluated expression).
@@ -932,6 +976,7 @@ pub enum ValueType {
   External,
 }
 
+#[cfg(feature = "expr")]
 impl ValueType {
   fn from_c(value_type: sys::ValueType) -> Self {
     match value_type {
@@ -951,6 +996,7 @@ impl ValueType {
   }
 }
 
+#[cfg(feature = "expr")]
 impl fmt::Display for ValueType {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let name = match self {
@@ -975,11 +1021,13 @@ impl fmt::Display for ValueType {
 /// This represents any value in the Nix language, including primitives,
 /// collections, and functions. Values are GC-managed; this struct holds
 /// a reference count that is released on drop.
+#[cfg(feature = "expr")]
 pub struct Value<'a> {
   pub(crate) inner: NonNull<sys::nix_value>,
   pub(crate) state: &'a EvalState,
 }
 
+#[cfg(feature = "expr")]
 impl Value<'_> {
   /// Force evaluation of this value.
   ///
@@ -1405,6 +1453,7 @@ impl Value<'_> {
   }
 }
 
+#[cfg(feature = "expr")]
 impl Drop for Value<'_> {
   fn drop(&mut self) {
     // SAFETY: We hold a GC reference (automatically incremented for us by
@@ -1415,6 +1464,7 @@ impl Drop for Value<'_> {
   }
 }
 
+#[cfg(feature = "expr")]
 impl fmt::Display for Value<'_> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self.value_type() {
@@ -1463,6 +1513,7 @@ impl fmt::Display for Value<'_> {
   }
 }
 
+#[cfg(feature = "expr")]
 impl fmt::Debug for Value<'_> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let value_type = self.value_type();
@@ -1512,10 +1563,11 @@ impl fmt::Debug for Value<'_> {
   }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "store", feature = "expr")))]
 mod tests {
   use super::*;
 
+  #[cfg(feature = "store")]
   #[test]
   #[serial]
   fn test_context_creation() {
@@ -1523,6 +1575,7 @@ mod tests {
     // Context should be dropped automatically
   }
 
+  #[cfg(feature = "store")]
   #[test]
   #[serial]
   fn test_nix_version() {
@@ -1530,6 +1583,7 @@ mod tests {
     assert!(!version.is_empty(), "Version should not be empty");
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_eval_state_builder() {
@@ -1543,6 +1597,7 @@ mod tests {
     // State should be dropped automatically
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_simple_evaluation() {
@@ -1562,6 +1617,7 @@ mod tests {
     assert_eq!(result.as_int().expect("Failed to get int value"), 3);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_value_types() {
@@ -1595,6 +1651,7 @@ mod tests {
     assert_eq!(str_val.as_string().expect("Failed to get string"), "hello");
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_value_construction() {
@@ -1622,6 +1679,7 @@ mod tests {
     assert_eq!(str_val.as_string().unwrap(), "hello");
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_make_list() {
@@ -1642,6 +1700,7 @@ mod tests {
     assert_eq!(list.list_len().unwrap(), 3);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_make_attrs() {
@@ -1666,6 +1725,7 @@ mod tests {
     assert_eq!(answer.as_int().unwrap(), 42);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_value_call() {
@@ -1685,6 +1745,7 @@ mod tests {
     assert_eq!(result.as_int().unwrap(), 42);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_value_copy() {
@@ -1701,6 +1762,7 @@ mod tests {
     assert_eq!(copy.as_int().unwrap(), 7);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_as_string_with_context_plain() {
@@ -1725,6 +1787,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_eval_from_file() {
@@ -1746,6 +1809,7 @@ mod tests {
     assert_eq!(result.as_int().unwrap(), 2);
   }
 
+  #[cfg(feature = "expr")]
   #[test]
   #[serial]
   fn test_no_load_config() {

--- a/nix-bindings/tests/integration.rs
+++ b/nix-bindings/tests/integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "expr")]
+
 use std::{process::Command, sync::Arc};
 
 use nix_bindings::{Context, EvalStateBuilder, Store, ValueType};

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,17 @@
 {pkgs ? import <nixpkgs> {}}: let
-  # FIXME: we eventually want to allow building for various Nix versions
-  # in the same dev shell. Instead of a 'nixForBindings' variable *here*
-  # it might be nicer to take environment variables which the build system
-  # can respect to build them using the appropriate Nix version.
+  # XXX: update comment or pin specific version on `nix flake update`.
+  # Generally the policy is to use the version corresponding to `pkgs.nix`'s
+  # in nixos-stable. Fortunately the C API does not move fast enough, so
+  # there is a degree of forward-compatibility.
   nixForBindings = pkgs.nixVersions.nix_2_32;
   inherit (pkgs.rustc) llvmPackages;
 in
   pkgs.mkShell {
     name = "nix-bindings";
-    packages = with pkgs; [
+
+    strictDeps = true;
+    nativeBuildInputs = with pkgs; [
+      pkg-config
       cargo
       rustc
       llvmPackages.lld
@@ -24,14 +27,9 @@ in
       cargo-nextest
     ];
 
-    nativeBuildInputs = with pkgs; [
-      nixForBindings.dev
-      pkg-config
-      glibc.dev
-    ];
-
     buildInputs = [
-      nixForBindings
+      nixForBindings.dev
+      pkgs.glibc.dev
     ];
 
     env = let


### PR DESCRIPTION
Adds feature gating system to both `nix-bindings` and `nix-bindings-sys` to allow fine-grained control over which parts of the bindings are compiled and included. Added modularity would be slightly nicer for conditional compilation and handling C library includes and linking based on enabled feature flags.

Also updates the Nix version used for linking to 2.32.8 and cleans up the Nix devshell.