### PR TITLE
meta: switch to Nix 2.34.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -293,7 +293,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix-bindings"
-version = "0.2328.1"
+version = "0.2347.0"
 dependencies = [
  "nix-bindings-sys",
  "serial_test",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "nix-bindings-sys"
-version = "0.2328.1"
+version = "0.2347.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ edition      = "2024"
 license      = "MIT"
 readme       = true
 repository   = "https://github.com/notashelf/nix-bindings"
-rust-version = "1.85.0"
-version      = "0.2328.1"
+rust-version = "1.90.0"
+version      = "0.2347.0"
 
 [workspace.dependencies]
-nix-bindings-sys = { path = "./nix-bindings-sys", version = "0.2328.0" }
+nix-bindings-sys = { path = "./nix-bindings-sys", version = "0.2347.0" }
 
 bindgen         = { default-features = false, features = [ "logging", "runtime" ], version = "0.72.1" }
-cc              = "1.2.61"
+cc              = "1.2.62"
 doxygen-bindgen = "0.1.3"
 pkg-config      = "0.3.33"
 serial_test     = "3.4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nix-bindings
 
-[![Rust Version](https://img.shields.io/badge/rust-1.85.0+-orange.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.90.0+-orange.svg)](https://www.rust-lang.org)
 
 [C API]: https://nix.dev/manual/nix/2.32/c-api
 [Nix]: https://nixos.org

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   # having a reference point, so we know what is ready for public use and what
   # is not. Security and critical performance improvements are always included
   # so it makes a good starting point.
-  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
 
   outputs = {nixpkgs, ...}: let
     systems = ["x86_64-linux" "aarch64-linux"];

--- a/nix-bindings-sys/tests/primop.rs
+++ b/nix-bindings-sys/tests/primop.rs
@@ -311,12 +311,18 @@ fn primop_function_call() {
       let init_err = nix_init_primop(ctx, primop_value, hello_primop);
       assert_eq!(init_err, nix_err_NIX_OK);
 
-      // Call the PrimOp (no arguments)
+      // Call the PrimOp with no arguments
       let result = nix_alloc_value(ctx, state);
       assert!(!result.is_null());
 
-      let call_err =
-        nix_value_call(ctx, state, primop_value, std::ptr::null_mut(), result);
+      let call_err = nix_value_call_multi(
+        ctx,
+        state,
+        primop_value,
+        0,
+        std::ptr::null_mut(),
+        result,
+      );
       if call_err == nix_err_NIX_OK {
         // Force the result
         let force_err = nix_value_force(ctx, state, result);

--- a/nix-bindings/src/external.rs
+++ b/nix-bindings/src/external.rs
@@ -213,10 +213,10 @@ static VTABLE: sys::NixCExternalValueDesc = {
     res: *mut sys::nix_string_return,
   ) {
     let payload = unsafe { ErasedPayload::from_void(self_) };
-    if let Some(s) = unsafe { (payload.coerce_fn)(payload.data) } {
-      if let Ok(cs) = CString::new(s) {
-        unsafe { sys::nix_set_string_return(res, cs.as_ptr()) };
-      }
+    if let Some(s) = unsafe { (payload.coerce_fn)(payload.data) }
+      && let Ok(cs) = CString::new(s)
+    {
+      unsafe { sys::nix_set_string_return(res, cs.as_ptr()) };
     }
   }
 

--- a/nix-bindings/src/primop.rs
+++ b/nix-bindings/src/primop.rs
@@ -398,7 +398,16 @@ impl PrimOp {
   {
     let name_c = CString::new(name)?;
     let doc_c = doc.map(CString::new).transpose()?;
-    let doc_ptr = doc_c.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
+    // PrimOp::doc is std::optional<std::string> since Nix 2.34.
+    // Passing null would throw "construction from null".
+    let empty_doc;
+    let doc_ptr = match doc_c {
+      Some(ref c) => c.as_ptr(),
+      None => {
+        empty_doc = CString::default();
+        empty_doc.as_ptr()
+      },
+    };
 
     // Box the closure together with its arity for the trampoline.
     let data = Box::new(ClosureData {
@@ -422,8 +431,11 @@ impl PrimOp {
     };
 
     if primop_ptr.is_null() {
-      // Allocation failed; free the closure ourselves.
       let _ = unsafe { Box::from_raw(data_raw as *mut ClosureData) };
+      // SAFETY: context pointer is valid
+      unsafe {
+        check_err(context.as_ptr(), sys::nix_err_code(context.as_ptr()))?;
+      }
       return Err(Error::NullPointer);
     }
 

--- a/nix-bindings/src/store.rs
+++ b/nix-bindings/src/store.rs
@@ -87,6 +87,80 @@ impl StorePath {
     result.ok_or(Error::NullPointer)
   }
 
+  /// Get the hash component of the store path as raw bytes.
+  ///
+  /// The 20-byte hash is decoded from the "nix32" encoding
+  /// in the store path. For example, for
+  /// `"/nix/store/abc123...-hello-1.0"` this returns the raw
+  /// hash bytes corresponding to `"abc123..."`.
+  ///
+  /// # Returns
+  ///
+  /// The raw 20-byte hash.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the hash cannot be retrieved.
+  pub fn hash_part(&self) -> Result<[u8; 20]> {
+    let mut hash = sys::nix_store_path_hash_part { bytes: [0u8; 20] };
+
+    // SAFETY: context and store path are valid
+    let err = unsafe {
+      sys::nix_store_path_hash(
+        self._context.as_ptr(),
+        self.inner.as_ptr(),
+        &mut hash,
+      )
+    };
+    check_err(unsafe { self._context.as_ptr() }, err)?;
+
+    Ok(hash.bytes)
+  }
+
+  /// Create a `StorePath` from its constituent hash and name parts.
+  ///
+  /// Unlike [`parse`](StorePath::parse), this does not require a `Store`
+  /// reference or the `/nix/store` prefix.
+  ///
+  /// # Arguments
+  ///
+  /// * `hash` - The 20-byte raw hash (as produced by
+  ///   [`hash_part`](Self::hash_part)).
+  /// * `name` - The name component (e.g., `"hello-1.0"`).
+  ///
+  /// # Returns
+  ///
+  /// A new `StorePath`.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the path cannot be created.
+  pub fn from_parts(
+    context: &Arc<Context>,
+    hash: &[u8; 20],
+    name: &str,
+  ) -> Result<Self> {
+    let hash_struct = sys::nix_store_path_hash_part { bytes: *hash };
+    let name_c = CString::new(name)?;
+
+    // SAFETY: context, hash, and name are valid
+    let path_ptr = unsafe {
+      sys::nix_store_create_from_parts(
+        context.as_ptr(),
+        &hash_struct,
+        name_c.as_ptr(),
+        name.len(),
+      )
+    };
+
+    let inner = NonNull::new(path_ptr).ok_or(Error::NullPointer)?;
+
+    Ok(StorePath {
+      inner,
+      _context: Arc::clone(context),
+    })
+  }
+
   /// Get the raw store path pointer.
   pub(crate) unsafe fn as_ptr(&self) -> *mut sys::StorePath {
     self.inner.as_ptr()
@@ -180,6 +254,71 @@ impl Derivation {
       inner,
       _context: Arc::clone(&self._context),
     })
+  }
+
+  /// Read a derivation from the store by its store path.
+  ///
+  /// # Returns
+  ///
+  /// The derivation object associated with the given `.drv` path.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the derivation cannot be read.
+  pub fn from_store_path(
+    context: &Arc<Context>,
+    store: &Store,
+    path: &StorePath,
+  ) -> Result<Self> {
+    // SAFETY: context, store, and path are valid
+    let drv_ptr = unsafe {
+      sys::nix_store_drv_from_store_path(
+        context.as_ptr(),
+        store.as_ptr(),
+        path.inner.as_ptr(),
+      )
+    };
+
+    if drv_ptr.is_null() {
+      return Err(Error::NullPointer);
+    }
+
+    Ok(Derivation {
+      inner:    drv_ptr,
+      _context: Arc::clone(context),
+    })
+  }
+
+  /// Serialize this derivation to its JSON representation.
+  ///
+  /// # Returns
+  ///
+  /// The derivation as a JSON string.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if serialization fails.
+  pub fn to_json(&self) -> Result<String> {
+    // SAFETY: inner is valid, callback matches expected signature
+    let result = unsafe {
+      string_from_callback(|cb, ud| {
+        sys::nix_derivation_to_json(self._context.as_ptr(), self.inner, cb, ud);
+      })
+    };
+    result.ok_or(Error::NullPointer)
+  }
+}
+
+impl Clone for Derivation {
+  fn clone(&self) -> Self {
+    // SAFETY: self.inner is valid
+    let cloned_ptr = unsafe { sys::nix_derivation_clone(self.inner) };
+    let inner = cloned_ptr; // raw pointer, Drop will free
+
+    Derivation {
+      inner,
+      _context: Arc::clone(&self._context),
+    }
   }
 }
 
@@ -440,6 +579,143 @@ impl Store {
       )
     };
     check_err(unsafe { self._context.as_ptr() }, err)
+  }
+
+  /// Copy a single path from this store into `dst_store`.
+  ///
+  /// Unlike [`copy_closure`](Self::copy_closure), this copies only the
+  /// path itself, not its dependencies.
+  ///
+  /// # Arguments
+  ///
+  /// * `repair` - Whether to repair the path if it is corrupted.
+  /// * `check_sigs` - Whether to verify path signatures before copying.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the copy operation fails.
+  pub fn copy_path(
+    &self,
+    dst_store: &Store,
+    path: &StorePath,
+    repair: bool,
+    check_sigs: bool,
+  ) -> Result<()> {
+    // SAFETY: all pointers are valid
+    let err = unsafe {
+      sys::nix_store_copy_path(
+        self._context.as_ptr(),
+        self.inner.as_ptr(),
+        dst_store.as_ptr(),
+        path.inner.as_ptr(),
+        repair,
+        check_sigs,
+      )
+    };
+    check_err(unsafe { self._context.as_ptr() }, err)
+  }
+
+  /// Enumerate the filesystem closure of a store path.
+  ///
+  /// Calls `callback` once for each store path in the closure (in no
+  /// particular order).
+  ///
+  /// # Arguments
+  ///
+  /// * `flip_direction` - If false, return paths referenced by paths in the
+  ///   closure (forward). If true, return paths that reference paths in the
+  ///   closure (backward).
+  /// * `include_outputs` - For derivations, also include their outputs.
+  /// * `include_derivers` - For outputs, also include the derivation that
+  ///   produced them.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the operation fails.
+  pub fn get_fs_closure<F>(
+    &self,
+    path: &StorePath,
+    flip_direction: bool,
+    include_outputs: bool,
+    include_derivers: bool,
+    mut callback: F,
+  ) -> Result<()>
+  where
+    F: FnMut(&StorePath),
+  {
+    type Userdata<'a> = (&'a mut dyn FnMut(&StorePath), Arc<Context>);
+
+    unsafe extern "C" fn closure_callback(
+      _context: *mut sys::nix_c_context,
+      userdata: *mut std::os::raw::c_void,
+      sp: *const sys::StorePath,
+    ) {
+      let data = unsafe { &mut *(userdata as *mut Userdata<'_>) };
+      let (cb, ctx) = data;
+
+      if !sp.is_null() {
+        let cloned = unsafe { sys::nix_store_path_clone(sp as *mut _) };
+        if let Some(inner) = NonNull::new(cloned) {
+          let p = StorePath {
+            inner,
+            _context: Arc::clone(ctx),
+          };
+          cb(&p);
+        }
+      }
+    }
+
+    let mut userdata: Userdata<'_> =
+      (&mut callback, Arc::clone(&self._context));
+    let userdata_ptr =
+      &mut userdata as *mut Userdata<'_> as *mut std::os::raw::c_void;
+
+    // SAFETY: all pointers are valid
+    let err = unsafe {
+      sys::nix_store_get_fs_closure(
+        self._context.as_ptr(),
+        self.inner.as_ptr(),
+        path.inner.as_ptr(),
+        flip_direction,
+        include_outputs,
+        include_derivers,
+        userdata_ptr,
+        Some(closure_callback),
+      )
+    };
+    check_err(unsafe { self._context.as_ptr() }, err)
+  }
+
+  /// Look up the full store path from a hash part.
+  ///
+  /// # Returns
+  ///
+  /// `Some(StorePath)` if a matching path exists, `None` otherwise.
+  pub fn query_path_from_hash_part(
+    &self,
+    hash: &str,
+  ) -> Result<Option<StorePath>> {
+    let hash_c = CString::new(hash)?;
+
+    // SAFETY: context, store, and hash_c are valid
+    let path_ptr = unsafe {
+      sys::nix_store_query_path_from_hash_part(
+        self._context.as_ptr(),
+        self.inner.as_ptr(),
+        hash_c.as_ptr(),
+      )
+    };
+
+    if path_ptr.is_null() {
+      return Ok(None);
+    }
+
+    let inner = NonNull::new(path_ptr).ok_or(Error::NullPointer)?;
+
+    Ok(Some(StorePath {
+      inner,
+      _context: Arc::clone(&self._context),
+    }))
   }
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
   # Generally the policy is to use the version corresponding to `pkgs.nix`'s
   # in nixos-stable. Fortunately the C API does not move fast enough, so
   # there is a degree of forward-compatibility.
-  nixForBindings = pkgs.nixVersions.nix_2_32;
+  nixForBindings = pkgs.nixVersions.nix_2_34;
   inherit (pkgs.rustc) llvmPackages;
 in
   pkgs.mkShell {


### PR DESCRIPTION
Updates the MSRV for nix-bindings and the Nix package set we link with. Current changes will not be backported as 26.05 is on the horizon.