### PR TITLE
Export more evaluator internals through C++ shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The repository contains a large test suite, examples, safety documentation, and
 The **low-level** bindings generated via [rust-bindgen] are located in the
 `nix-bindings-sys` crate in [`nix-bindings-sys/`](./nix-bindings-sys). By
 default, the low-level bindings crate covers **all public Nix C API headers**,
-including the store, evaluator, error, flake, and main APIs.
+including the store, evaluator, error, flake, and main APIs. There exists an
+attempt to support the C++ APIs as well, but those should be approached with
+caution due to upstream's treatment of the C++ APIs. Read below for details.
 
 The [`nix-bindings/`](./nix-bindings) crate wraps `nix-bindings-sys` and
 attempts to provide a more robust, **high-level** API for interacting with Nix
@@ -41,12 +43,18 @@ using Rust through a cleaner interface with additional safety documentation,
 testing, examples and more.
 
 > [!NOTE]
-> Due to the limitations of rust-bindgen, there is no compatibility outside the
-> public C API. As much as I would love to provide bindings for the C++ APIs,
-> this seems very annoying and is [discouraged by Bindgen]. For interacting with
-> C++ APIs, you might want to use C++ directly. See [this blog post] that
-> inspired this repository for instructions on using Nix as a library in C++
-> projects.
+> Previously, due to the limitations of rust-bindgen, this crate refused to
+> provide compatibility outside the public C API. My reasoning for this decision
+> was that it is very annoying to provide bindings for the _unstable_ C++ API,
+> and doing so is [discouraged by Bindgen]. This document used to cite
+> [this blog post] that inspired this repository for instructions on using Nix
+> as a library in C++ projects.
+>
+> As of v0.2347.2, this crate **provides experimental C++ shims**. This is very
+> much discouraged, but is the only way to work around the quirks and the status
+> of the C API. There is an effort to make those reliable, sound, and
+> _idiomatic_ but none of those can be guaranteed. Please be careful if you're
+> interacting with the C++ shims and remember to report any issues!
 
 ## Repository Layout
 
@@ -80,10 +88,12 @@ comments, examples and everything else provided by individual crate READMEs.
 
 ## Contributing
 
+[`CONTRIBUTING.md`]: ./CONTRIBUTING.md
+
 Contributions are welcome! If you have noticed something missing and would like
 to patch it yourself, I would appreciate contributions. Please read
-[`CONTRIBUTING.md`](./CONTRIBUTING.md) first; it covers about everything you
-need to know, but here is a short version:
+[`CONTRIBUTING.md`] first; it covers about everything you need to know, but here
+is a short version:
 
 - Keep examples and tests small, focused, and idiomatic
 - Follow Rust FFI safety best practices

--- a/nix-bindings-sys/build.rs
+++ b/nix-bindings-sys/build.rs
@@ -26,6 +26,7 @@ fn main() {
   println!("cargo:rerun-if-changed=include/nix_api_expr_shim.h");
   println!("cargo:rerun-if-changed=src/wrappers/add_to_store.cc");
   println!("cargo:rerun-if-changed=src/wrappers/init_path.cc");
+  println!("cargo:rerun-if-changed=src/wrappers/eval.cc");
 
   // docs.rs has no Nix system libraries. Write empty bindings so the crate
   // compiles and return before any pkg-config or cc invocation.
@@ -124,13 +125,23 @@ fn main() {
     }
 
     if env::var("CARGO_FEATURE_EXPR").is_ok() {
-      // Only probe the C API package. nix-expr.pc (C++) pulls in transitive
-      // deps (gc, boost, ...) that downstream builds may not expose. The C++
-      // include root is already covered by the nix-store/nix-util includes
-      // above; nix-expr-c supplies the internal C API headers we actually need.
+      // Probe the C API package for its internal headers
+      // (nix_api_expr_internal.h, etc.).
       let lib = pkg_config::probe_library("nix-expr-c")
         .unwrap_or_else(|_| panic!("Unable to find .pc file for nix-expr-c"));
       for path in &lib.include_paths {
+        cc_build.include(path);
+      }
+
+      // eval.cc needs get-drvs.hh from the C++ nix-expr package. Probe for
+      // include paths only; cargo_metadata(false) suppresses the transitive
+      // link directives (gc, boost, ...) that nix-expr.pc carries and that
+      // downstream builds may not expose.
+      let expr_lib = pkg_config::Config::new()
+        .cargo_metadata(false)
+        .probe("nix-expr")
+        .unwrap_or_else(|_| panic!("Unable to find .pc file for nix-expr"));
+      for path in &expr_lib.include_paths {
         cc_build.include(path);
       }
     }
@@ -156,10 +167,10 @@ fn main() {
 
     if env::var("CARGO_FEATURE_EXPR").is_ok() {
       cc_build.file("src/wrappers/init_path.cc");
-      // init_path.cc calls nix::EvalState::allowPath, which lives in the
-      // C++ libnixexpr (not in the C wrapper libnixexprc that pkg-config
-      // for nix-expr-c reports). Force the C++ library onto the link line
-      // so dependent crates that only touch the C API still link.
+      cc_build.file("src/wrappers/eval.cc");
+      // Both init_path.cc and eval.cc call into C++ libnixexpr (allowPath,
+      // getDerivation, autoCallFunction). Force it onto the link line so
+      // dependent crates that only use the C API still link correctly.
       println!("cargo:rustc-link-lib=dylib=nixexpr");
     }
 

--- a/nix-bindings-sys/include/nix_api_expr_shim.h
+++ b/nix-bindings-sys/include/nix_api_expr_shim.h
@@ -29,6 +29,47 @@ extern "C" {
 nix_err nix_eval_state_allow_path(nix_c_context *context, EvalState *state,
                                   const char *str);
 
+/**
+ * @brief Determine whether a Nix value is a derivation and return its path.
+ *
+ * Forces @p value and, if it is a derivation, returns a newly allocated
+ * StorePath for its `.drvPath`. If the value is not a derivation, NULL is
+ * returned without setting an error. If forcing the value raises an assertion
+ * failure and @p ignoreAssertionFailures is true, the assertion failure is
+ * treated as "not a derivation" (NULL returned, no error); if false, the
+ * assertion is propagated as an error.
+ *
+ * @param[out] context Optional. Stores error information.
+ * @param[in]  state   Evaluator state.
+ * @param[in]  value   Value to inspect.
+ * @param[in]  ignoreAssertionFailures When true, an AssertionError raised while
+ *  forcing @p value is treated as "not a derivation" rather than an error.
+ * @return A newly allocated StorePath holding the derivation path, or NULL.
+ *  Free a non-NULL result with nix_store_path_free().
+ */
+StorePath *nix_get_derivation(nix_c_context *context, EvalState *state,
+                              nix_value *value, bool ignoreAssertionFailures);
+
+/**
+ * @brief Call a function, drawing its arguments from an attribute set.
+ *
+ * Forces @p fn_val and writes its application into @p result. If @p fn_val is
+ * a function that expects named arguments, each argument is looked up in @p
+ * auto_args; formals with defaults that are absent from @p auto_args use their
+ * defaults. If @p auto_args is NULL or not an attribute set, empty bindings are
+ * supplied (every formal must then have a default value).
+ *
+ * @param[out] context   Optional. Stores error information.
+ * @param[in]  state     Evaluator state.
+ * @param[in]  auto_args Attribute set value supplying named arguments, or NULL.
+ * @param[in]  fn_val    The value to call.
+ * @param[out] result    Pre-allocated nix_value that receives the result.
+ * @return NIX_OK on success, an error code otherwise.
+ */
+nix_err nix_value_auto_call_function(nix_c_context *context, EvalState *state,
+                                     nix_value *auto_args, nix_value *fn_val,
+                                     nix_value *result);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nix-bindings-sys/src/wrappers/eval.cc
+++ b/nix-bindings-sys/src/wrappers/eval.cc
@@ -1,0 +1,74 @@
+// Shims for nix_get_derivation and nix_value_auto_call_function.
+//
+// These mirror the functions I've proposed in NixOS/nix#15842. The PR has been
+// stalled upstream, so we implement them locally using the same strategy:
+// access nix::getDerivation and EvalState::autoCallFunction through the C++
+// API and wrap them in C linkage with NIXC_CATCH_ERRS error translation.
+//
+// XXX: check_value_in is NOT yet exported from nix_api_expr_internal.h in
+// the installed 2.34.x headers, so we dereference nix_value->value directly
+// with explicit null guards instead.
+//
+// FIXME: hopefully this is temporary. C++ shims are the bane of my existence.
+
+#include <nix/expr/eval.hh>
+#include <nix/expr/get-drvs.hh>
+
+#include <nix_api_expr.h>
+#include <nix_api_expr_internal.h>
+#include <nix_api_store.h>
+#include <nix_api_store_internal.h>
+#include <nix_api_util.h>
+#include <nix_api_util_internal.h>
+
+#include "nix_api_expr_shim.h"
+
+static const nix::Bindings *get_bindings_or_null(nix_value *autoArgs) {
+  if (!autoArgs || !autoArgs->value)
+    return nullptr;
+  auto &v = *autoArgs->value;
+  if (v.type() == nix::nAttrs)
+    return v.attrs();
+  return nullptr;
+}
+
+extern "C" {
+
+StorePath *nix_get_derivation(nix_c_context *context, EvalState *state,
+                              nix_value *value, bool ignoreAssertionFailures) {
+  if (context)
+    context->last_err_code = NIX_OK;
+  if (!state || !value || !value->value)
+    return nullptr;
+  try {
+    auto &v = *value->value;
+    auto maybePkg =
+        nix::getDerivation(state->state, v, ignoreAssertionFailures);
+    if (!maybePkg)
+      return nullptr;
+    nix::StorePath sp = maybePkg->requireDrvPath();
+    return new StorePath{std::move(sp)};
+  }
+  NIXC_CATCH_ERRS_NULL
+}
+
+nix_err nix_value_auto_call_function(nix_c_context *context, EvalState *state,
+                                     nix_value *auto_args, nix_value *fn_val,
+                                     nix_value *result) {
+  if (context)
+    context->last_err_code = NIX_OK;
+  if (!state || !fn_val || !fn_val->value || !result || !result->value)
+    return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "null argument");
+  try {
+    auto &fn = *fn_val->value;
+    auto &res = *result->value;
+    const nix::Bindings *b = get_bindings_or_null(auto_args);
+    if (b)
+      state->state.autoCallFunction(*b, fn, res);
+    else
+      state->state.autoCallFunction(nix::Bindings::emptyBindings, fn, res);
+  }
+  NIXC_CATCH_ERRS
+}
+
+} // extern "C"

--- a/nix-bindings/src/eval.rs
+++ b/nix-bindings/src/eval.rs
@@ -10,6 +10,7 @@ use crate::{
   Error,
   Result,
   Store,
+  StorePath,
   Value,
   context::is_pure_eval,
   error::check_err,
@@ -520,6 +521,90 @@ impl EvalState {
           self.context.as_ptr(),
           result.inner.as_ptr(),
           builder,
+        ),
+      )?;
+    }
+
+    Ok(result)
+  }
+
+  /// Determine whether a value is a derivation and return its store path.
+  ///
+  /// Forces `value` and, if it is a derivation, returns a newly allocated
+  /// [`StorePath`] for its `.drvPath`. Returns `Ok(None)` when the value is
+  /// not a derivation. An exception raised during forcing propagates as
+  /// `Err(...)`.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if forcing the value raises a Nix exception.
+  #[cfg(feature = "shim")]
+  pub fn get_derivation(&self, value: &Value<'_>) -> Result<Option<StorePath>> {
+    // SAFETY: context, state, and value are valid for the call duration.
+    let path_ptr = unsafe {
+      sys::nix_get_derivation(
+        self.context.as_ptr(),
+        self.inner.as_ptr(),
+        value.inner.as_ptr(),
+        false,
+      )
+    };
+
+    if path_ptr.is_null() {
+      // NIXC_CATCH_ERRS_NULL sets last_err_code on exception. A plain null
+      // (no exception, maybePkg was empty) leaves last_err_code at NIX_OK.
+      // SAFETY: context is valid for the lifetime of self.
+      unsafe {
+        let ctx = self.context.as_ptr();
+        let code = sys::nix_err_code(ctx);
+        check_err(ctx, code)?;
+      }
+      return Ok(None);
+    }
+
+    let inner = NonNull::new(path_ptr).ok_or(Error::NullPointer)?;
+    Ok(Some(StorePath {
+      inner,
+      _context: Arc::clone(&self.context),
+    }))
+  }
+
+  /// Call a function using an attribute set as its argument source.
+  ///
+  /// Forces `fn_val` and writes the result into a newly allocated value:
+  ///
+  /// - If `fn_val` is a function with named formals, each formal is looked up
+  ///   in `auto_args`; formals with defaults that are absent from `auto_args`
+  ///   use their defaults.
+  /// - If `auto_args` is `None`, empty bindings are supplied (every formal must
+  ///   then have a default).
+  /// - If `fn_val` is not a function, the value is copied to the result
+  ///   unchanged.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the call fails.
+  #[cfg(feature = "shim")]
+  pub fn auto_call_function<'s>(
+    &'s self,
+    auto_args: Option<&Value<'_>>,
+    fn_val: &Value<'_>,
+  ) -> Result<Value<'s>> {
+    let result = self.alloc_value()?;
+    let auto_args_ptr =
+      auto_args.map_or(std::ptr::null_mut(), |v| v.inner.as_ptr());
+
+    // SAFETY: context, state, auto_args_ptr (null or valid), fn_val, and
+    // result are all valid for the call duration.
+    unsafe {
+      check_err(
+        self.context.as_ptr(),
+        sys::nix_value_auto_call_function(
+          self.context.as_ptr(),
+          self.inner.as_ptr(),
+          auto_args_ptr,
+          fn_val.inner.as_ptr(),
+          result.inner.as_ptr(),
         ),
       )?;
     }


### PR DESCRIPTION
Horrible hack.

See #39 