### PR TITLE
 Remove linux specific gcc tricks 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
   outputs = {nixpkgs, ...}: let
-    systems = ["x86_64-linux" "aarch64-linux"];
+    systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
     pkgsForEach = nixpkgs.legacyPackages;
   in {

--- a/nix-bindings-sys/build.rs
+++ b/nix-bindings-sys/build.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::expect_used)]
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
 
 use bindgen::callbacks::ParseCallbacks;
 
@@ -37,21 +37,12 @@ fn main() {
     return;
   }
 
-  // Dynamically get GCC's include path for standard headers (e.g., stdbool.h)
-  let gcc_include = Command::new("gcc")
-    .arg("-print-file-name=include")
-    .output()
-    .expect("Failed to get gcc include path")
-    .stdout;
-  let gcc_include = String::from_utf8_lossy(&gcc_include).trim().to_string();
-
   let mut builder = bindgen::Builder::default()
     .header("include/wrapper.h")
     .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
     .formatter(bindgen::Formatter::Rustfmt)
     .rustfmt_configuration_file(std::fs::canonicalize(".rustfmt.toml").ok())
     .parse_callbacks(Box::new(ProcessComments))
-    .clang_arg(format!("-I{gcc_include}"))
     .clang_arg("-Iinclude");
 
   // (Cargo feature env var, preprocessor define, optional pkg-config lib name)

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@
   # in nixos-stable. Fortunately the C API does not move fast enough, so
   # there is a degree of forward-compatibility.
   nixForBindings = pkgs.nixVersions.nix_2_34;
+  inherit (pkgs) lib;
   inherit (pkgs.rustc) llvmPackages;
 in
   pkgs.mkShell {
@@ -29,6 +30,7 @@ in
 
     buildInputs = [
       nixForBindings.dev
+    ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
       pkgs.glibc.dev
     ];
 
@@ -37,11 +39,12 @@ in
     in {
       RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
       LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-      BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${pkgs.glibc.dev}";
 
       # `cargo-llvm-cov` reads these environment variables to find these binaries,
       # which are needed to run the tests
       LLVM_COV = "${llvm}/bin/llvm-cov";
       LLVM_PROFDATA = "${llvm}/bin/llvm-profdata";
+    } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+      BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${pkgs.glibc.dev}";
     };
   }


### PR DESCRIPTION
I only tested this by doing cargo b on linux and macos. Not sure if library consumers are effected by this.